### PR TITLE
Makefile improve: Build artifacts are moving for a build/ directorie

### DIFF
--- a/smartlamp-kernel-module/Makefile
+++ b/smartlamp-kernel-module/Makefile
@@ -1,8 +1,22 @@
 obj-m += probe.o
 PWD := $(CURDIR)
+OUTDIR := $(PWD)/build
 
 all:
+	rm -rf $(OUTDIR)
+	mkdir -p $(OUTDIR)
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	find . -maxdepth 1 -type f \( \
+		-name '*.o' -o \
+		-name '*.ko' -o \
+		-name '*.mod' -o \
+		-name '*.mod.*' -o \
+		-name '*.symvers' -o \
+		-name '*.order' -o \
+		-name '*.cmd' -o \
+		-name '.*.cmd' \
+	\) -exec mv -t $(OUTDIR) {} +
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	rm -rf $(OUTDIR)


### PR DESCRIPTION
Makefile now will create a build subdirectorie, and all artifacts when compiled, will be moved for this subdirectorie. In a new build, the previews artifacts will be deleted